### PR TITLE
do not assume unix style serial port naming convention

### DIFF
--- a/pytrios/TClasses.py
+++ b/pytrios/TClasses.py
@@ -27,7 +27,7 @@ class TSerial(Serial):
                  parity='N', stopbits=1, bytesize=8):#, verbosity=1):
         try:
             port = str(port)
-            port = "/dev/ttyUSB"+port.strip('/dev/ttyUSB')
+            #port = "/dev/ttyUSB"+port.strip('/dev/ttyUSB')  # be less presprictively unix
             Serial.__init__(self, port)
             self.baudrate = baudrate
             self.timeout = timeout


### PR DESCRIPTION
fixes https://github.com/StefanSimis/PyTrios/issues/6

