### PR TITLE
8 allow pytrios to be installed via pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,7 @@
 # For package installation: pip install .
 # For editable package: pip install -e .
 #
-# See also:
-# - https://packaging.python.org/en/latest/tutorials/packaging-projects/
-# - https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/
-# - https://docs.pytest.org/en/latest/explanation/goodpractices.html
-# - https://realpython.com/python-application-layouts/
+# To uninstall: pip uninstall pytrios
 
 [build-system]
 requires = ["hatchling", "numpy", "pyserial>=3.4"]
@@ -16,8 +12,3 @@ build-backend = "hatchling.build"
 [project]
 name = "pytrios"
 version = "1.0.0"
-
-[tool.pytest.ini_options]
-addopts = [
-    "--import-mode=importlib",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 # Package creation file.
 #
+# For package installation: pip install .
 # For editable package: pip install -e .
 #
 # See also:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+# Package creation file.
+#
+# For editable package: pip install -e .
+#
+# See also:
+# - https://packaging.python.org/en/latest/tutorials/packaging-projects/
+# - https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/
+# - https://docs.pytest.org/en/latest/explanation/goodpractices.html
+# - https://realpython.com/python-application-layouts/
+
+[build-system]
+requires = ["hatchling", "numpy", "pyserial>=3.4"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pytrios"
+version = "1.0.0"
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]


### PR DESCRIPTION
Hi @StefanSimis, please review this minimal `pyproject.toml` for installing `pytrios` as a package so elsewhere I can say:
~~~
from pytrios import radman
~~~
for example.

To handle installation of scripts, changing package structure to handle unit tests etc, more would need to be done.