### PR TITLE
Correct interpolation and dark pixel offset

### DIFF
--- a/ramses_calibrate.py
+++ b/ramses_calibrate.py
@@ -199,7 +199,7 @@ def raw2cal_Air(spec, msdate, serialn,
     if len(calsensind) > 1:
         calsensdates = [SAMDateTime_Air[i] for i in calsensind]
         tdeltas = [(msdate-x) for x in calsensdates
-                   if (msdate-x).days > 0]
+                if (msdate-x).days > 0]
         calsensind = [calsensind[tdeltas.index(min(tdeltas))]]
 
     Cal = CalData[calsensind[0]]
@@ -209,8 +209,8 @@ def raw2cal_Air(spec, msdate, serialn,
     dp1 = Cal.ini.DarkPixelStart
     dp2 = Cal.ini.DarkPixelStop
     wave = [0.0] * 256
-    for i in range(1, len(wave)+1, 1):
-        wave[i-1] = (Cal.ini.c0s) + (Cal.ini.c1s*(i+1)) +\
+    for i in range(0, len(wave), 1):
+        wave[i] = (Cal.ini.c0s) + (Cal.ini.c1s*(i+1)) +\
             (Cal.ini.c2s*(i+1)**2) + (Cal.ini.c3s*(i+1)**3)
 
     t0 = 8192
@@ -222,7 +222,7 @@ def raw2cal_Air(spec, msdate, serialn,
     B = B0 + (t1/t0*B1)
     C = M - B
     # subtract dark offset,
-    Offset = np.mean(C[dp1-1:dp2])  # dark pixels
+    Offset = np.mean(C[dp1:dp2+1])  # dark pixels 
     D = C-Offset
     E = D*(t0/t1)
     # Scale the spectrum to the Air calibration


### PR DESCRIPTION
Hi,
I have tried to verify the calibration and dark-pixel offset in ramses_calibrate.py by testing with a RAMSES sensor in an optical lab with a mercury test tube. Below is a plot comparing the original pytrios code by a modification done by my former colleague Artur Zolich. The vertical lines are the expected peaks of mercury, at [365, 405, 435, 546] nm. As you can see, the code by Zolich fits better.

<img width="2151" height="1175" alt="image" src="https://github.com/user-attachments/assets/cd2ab7fd-7ad3-432b-b730-3784009b1d35" />

Let me know if you would like me to send you the numerical values used in the plot, and/or the raw data from the sensor.

To be clear: this fix was made by Artur by comparing the output from MSDA with pytrios. I know he has been in contact with you on that, via email. I have also been in contact with Triosm, who confirm that there is an error in the indexing in the interpolation in the manual (but frustratingly became radio-silent after that), and one of our research partners who also confirm having problems with this.

I hope that this PR can fix the problem, and clear the confusion.

Regards,
Kristoffer